### PR TITLE
POST category

### DIFF
--- a/categories/request.py
+++ b/categories/request.py
@@ -1,0 +1,46 @@
+import sqlite3, json
+from models import Post
+
+def get_all_categories():
+    with sqlite3.connect("./rare.db") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        SELECT
+            id,
+            label
+        FROM Categories
+        """)
+
+        dataset = db_cursor.fetchall()
+
+        categories = []
+
+        for row in dataset:
+            cat = {
+                "id": row['id'],
+                "label": row['label']
+                }
+            categories.append(cat)
+            
+
+    return json.dumps(categories)
+
+def create_category(new_category):
+    with sqlite3.connect("./rare.db") as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        INSERT INTO Categories
+            (label)
+        VALUES
+            ( ? );
+        
+        """, (new_category['label'], ))
+
+        id = db_cursor.lastrowid
+        new_category['id'] = id
+
+    return json.dumps(new_category)
+

--- a/models/category.py
+++ b/models/category.py
@@ -1,0 +1,4 @@
+class Category():
+    def __init__(self, id, label):
+        self.id = id
+        self.label = label

--- a/request_handler.py
+++ b/request_handler.py
@@ -1,3 +1,4 @@
+from categories.request import create_category, get_all_categories
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 
@@ -52,6 +53,8 @@ class HandleRequests(BaseHTTPRequestHandler):
             resource, id = parsed
             if resource == "posts":
                 response = f"{get_all_posts()}"
+            elif resource == "categories":
+                response = f"{get_all_categories()}"
 
         self.wfile.write(f"{response}".encode())
 
@@ -83,6 +86,8 @@ class HandleRequests(BaseHTTPRequestHandler):
 
         if resource == "register":
             new_item = register_user(post_body)
+        if resource == "categories":
+            new_item = create_category(post_body)
 
         self.wfile.write(f"{new_item}".encode())
 


### PR DESCRIPTION
# POST route for a single category now works

Closes #7 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

1. on the client side, please check out ram-create-a-category
2. launch both the app and the server
3. login
4. click "categories"
5. click "create new category"
6. add a new category


# Checklist:
- [ ] I can see all (one) of the categories from the DB when I click on categories in the navbar
- [ ] I can add a new category
- [ ] I can see the new category after I've submitted it
